### PR TITLE
System wide dconf defaults

### DIFF
--- a/defaults/main/dconf.yml
+++ b/defaults/main/dconf.yml
@@ -1,0 +1,158 @@
+gnome_systemwide_default_base: "/etc/dconf/db/local.d/00-gnome-base"
+gnome_settings_fallback: "43"
+gnome_base_settings:
+  "dconf_default": &dconf_default
+    "system/locale/region": "'en_GB.UTF-8'"
+    "org/gnome/desktop/interface/enable-hot-corners": "false"
+    "org/gnome/desktop/input-sources/sources": "[('xkb', 'us+euro'), ('xkb', 'de')]"
+    "org/gnome/desktop/input-sources/sources/per-window": "false"
+    "org/gnome/desktop/input-sources/mru-sources": "[['xkb', 'us+euro'], ['xkb', 'de']]"
+    "org/gnome/desktop/input-sources/xkb-options": "['caps:none']"
+    "org/gnome/desktop/wm/keybindings/activate-window-menu": "@as []"
+    "org/gnome/desktop/wm/preferences/action-middle-click-titlebar": "'minimize'"
+    "org/gnome/mutter/attach-modal-dialogs": "false"
+    "org/gnome/shell/overrides/attach-modal-dialogs": "false"
+    "org/gnome/mutter/center-new-windows": "false"
+    "org/gnome/mutter/edge-tiling": "false"
+    "org/gnome/desktop/interface/clock-show-weekday": "true"
+    "org/gnome/desktop/interface/font-name": "'Cantarell Bold 11'"
+    "org/gnome/desktop/wm/preferences/titlebar-font": "'Carlito Bold Italic 11'"
+    "org/gnome/tweaks/show-extensions-notice": "false"
+    "org/gnome/desktop/wm/preferences/button-layout": "'close,maximize,minimize:appmenu'"
+    "org/gnome/software/download-updates": "false"
+    "org/gnome/software/first-run": "false"
+  "40":
+    # Note obsolete if custom theme gets set
+    # "/org/gnome/desktop/interface/gtk-theme": "'Adwaita-dark'"
+    <<: *dconf_default
+  "42": &42  # global dark theme
+    # Note obsolete if custom theme gets set
+    # "/org/gnome/shell/extensions/user-theme/name": "'Yaru-magenta-dark'"
+    <<: *dconf_default
+    "org/gnome/desktop/interface/color-scheme": "'prefer-dark'"
+  "43": &43
+    <<: *42
+    "org/gnome/desktop/privacy/old-files-age": "30"
+    "org/gnome/desktop/privacy/recent-files-max-age": "30"
+    "org/gnome/desktop/privacy/remove-old-temp-files": "true"
+    "org/gnome/desktop/privacy/remove-old-trash-files": "true"
+  "47":
+    <<: *43
+  "49":
+    <<: *43
+
+# Note partly broken visible columns show no effect
+gnome_systemwide_default_nautilus: "/etc/dconf/db/local.d/10-gnome-nautilus"
+gnome_nautilus_settings:
+  "base_settings": &base_settings
+    "org/gnome/nautilus/icon-view/captions": "['detailed_type', 'size', 'date_modified_with_time']"
+    "org/gnome/nautilus/list-view/default-visible-columns": "['name', 'size', 'date_modified_with_time', 'detailed_type']"
+    "org/gnome/nautilus/list-view/default-column-order": "['name', 'size', 'mime_type', 'date_modified_with_time', 'type', 'owner', 'group', 'permissions', 'where', 'date_modified', 'date_accessed', 'date_created', 'recency', 'starred']"
+    "org/gnome/nautilus/list-view/default-zoom-level": "'small'"
+    "org/gnome/nautilus/list-view/default-zoom-level/use-tree-view": "true"
+    "org/gnome/nautilus/preferences/default-folder-viewer": "'list-view'"
+    "org/gnome/nautilus/preferences/migrated-gtk-settings": "true"
+    "org/gnome/nautilus/preferences/search-filter-time-type": "'last_modified'"
+    "org/gnome/nautilus/preferences/show-create-link": "true"
+    "org/gnome/nautilus/preferences/show-delete-permanently": "true"
+    "org/gnome/nautilus/preferences/show-image-thumbnails": "'always'"
+  "40":
+    <<: *base_settings
+    "org/gtk/settings/file-chooser/sort-directories-first": "true"
+    "org/gtk/settings/file-chooser/date-format": "'regular'"
+    "org/gtk/settings/file-chooser/location-mode": "'path-bar'"
+    "org/gtk/settings/file-chooser/show-hidden": "false"
+    "org/gtk/settings/file-chooser/show-size-column": "true"
+    "org/gtk/settings/file-chooser/show-type-column": "true"
+    "org/gtk/settings/file-chooser/sort-column": "'name'"
+    "org/gtk/settings/file-chooser/sort-order": "'ascending'"
+    "org/gtk/settings/file-chooser/type-format": "'category'"
+    "org/gtk/settings/file-chooser/view-type": "'list'"
+  "42": &gtk4_settings
+    <<: *base_settings
+    "org/gtk/gtk4/settings/file-chooser/sort-directories-first": "true"
+    "org/gtk/gtk4/settings/file-chooser/date-format": "'regular'"
+    "org/gtk/gtk4/settings/file-chooser/location-mode": "'path-bar'"
+    "org/gtk/gtk4/settings/file-chooser/show-hidden": "false"
+    "org/gtk/gtk4/settings/file-chooser/show-size-column": "true"
+    "org/gtk/gtk4/settings/file-chooser/show-type-column": "true"
+    "org/gtk/gtk4/settings/file-chooser/sort-column": "'name'"
+    "org/gtk/gtk4/settings/file-chooser/sort-order": "'ascending'"
+    "org/gtk/gtk4/settings/file-chooser/type-format": "'category'"
+    "org/gtk/gtk4/settings/file-chooser/view-type": "'list'"
+  "43":
+    <<: *gtk4_settings
+  "47":
+    <<: *gtk4_settings
+  "49":
+    <<: *gtk4_settings
+
+gnome_systemwide_default_terminal: "/etc/dconf/db/local.d/10-gnome-terminal"
+terminal_profile_uuid: "5261d7f3-37ae-43cc-90e5-2139da18c41d"
+gnome_terminal_settings:
+  "org/gnome/terminal/legacy/settings/new-terminal-mode": "'tab'"
+  "org/gnome/terminal/legacy/settings/set-terminal-title": "'disabled'"
+  "org/gnome/terminal/legacy/settings/shell-integration": "true"
+  "org/gnome/terminal/legacy/settings/confirm-close": "true"
+  "org/gnome/terminal/legacy/settings/new-tab-position": "'last'"
+  "org/gnome/terminal/legacy/settings/tab-policy": "'automatic'"
+  "org/gnome/terminal/legacy/settings/theme-variant": "'dark'"
+  "org/gnome/terminal/legacy/profiles:/list": "['{{ terminal_profile_uuid }}']"
+  "org/gnome/terminal/legacy/profiles:/default": "'{{ terminal_profile_uuid }}'"
+
+gnome_terminal_profile_path: "org/gnome/terminal/legacy/profiles:{{ terminal_profile_uuid }}"
+gnome_terminal_profile_settings:
+  "visible-name": "'default'"
+  "audible-bell": "false"
+  "background-color": "'rgb(28,28,28)'"
+  "background-transparency-percent": "20"
+  "bold-color": "'rgb(147,15,182)'"
+  "bold-color-same-as-fg": "false"
+  "bold-is-bright": "true"
+  "cursor-background-color": "'rgb(84,85,139)'"
+  "cursor-colors-set": "true"
+  "cursor-foreground-color": "'rgb(163,101,181)'"
+  "default-size-columns": "80"
+  "default-size-rows": "24"
+  "font": "'Liberation Mono 14'"
+  "use-system-font": "false"
+  "foreground-color": "'rgb(198,141,232)'"
+  "highlight-background-color": "'rgb(128,105,128)'"
+  "highlight-colors-set": "true"
+  "highlight-foreground-color": "'rgb(214,90,232)'"
+  "palette": "['rgb(23,20,33)', 'rgb(192,28,40)', 'rgb(38,162,105)', 'rgb(162,115,76)', 'rgb(18,72,139)', 'rgb(163,71,186)', 'rgb(42,161,179)', 'rgb(208,207,204)', 'rgb(94,92,100)', 'rgb(246,97,81)', 'rgb(51,209,122)', 'rgb(233,173,12)', 'rgb(42,123,222)', 'rgb(192,97,203)', 'rgb(51,199,222)', 'rgb(255,255,255)']"
+  "scrollbar-policy": "'never'"
+  "use-theme-colors": "false"
+  "use-transparent-background": "true"
+
+gnome_systemwide_default_gedit: "/etc/dconf/db/local.d/10-gnome-gedit"
+gedit_system_theme_path: "/usr/share/gtksourceview-4/styles"
+gnome_gedit_settings:
+  "org/gnome/gedit/preferences/editor/auto-indent": "true"
+  "org/gnome/gedit/preferences/editor/bracket-matching": "true"
+  "org/gnome/gedit/preferences/editor/highlight-current-line": "true"
+  "org/gnome/gedit/preferences/editor/right-margin-position": "uint32 80"
+  "org/gnome/gedit/preferences/editor/display-line-numbers": "true"
+  "org/gnome/gedit/preferences/editor/display-overview-map": "true"
+  "org/gnome/gedit/preferences/editor/scheme": "'lavanda'"
+  "org/gnome/gedit/preferences/editor/syntax-highlighting": "true"
+  "org/gnome/gedit/preferences/editor/tabs-size": "uint32 2"
+  "org/gnome/gedit/preferences/editor/use-default-font": "false"
+  "org/gnome/gedit/preferences/editor/ensure-trailing-newline": "true"
+  "org/gnome/gedit/preferences/ui/bottom-panel-visible": "false"
+  "org/gnome/gedit/preferences/ui/side-panel-visible": "false"
+  "org/gnome/gedit/preferences/ui/show-tabs-mode": "'auto'"
+  "org/gnome/gedit/plugins/active-plugins": "['textsize', 'terminal', 'findinfiles', 'drawspaces', 'bracketcompletion', 'bookmarks', 'spell', 'sort', 'quickhighlight', 'modelines', 'filebrowser', 'docinfo']"
+  "org/gnome/gedit/plugins/spell/highlight-misspelled": "true"
+
+gnome_systemwide_default_meld: "/etc/dconf/db/local.d/10-gnome-meld"
+gnome_meld_settings:
+  "org/gnome/meld/enable-space-drawer": "true"
+  "org/gnome/meld/highlight-current-line": "true"
+  "org/gnome/meld/highlight-syntax": "true"
+  "org/gnome/meld/indent-width": "4"
+  "org/gnome/meld/prefer-dark-theme": "true"
+  "org/gnome/meld/show-line-numbers": "true"
+  "org/gnome/meld/style-scheme": "'oblivion'"
+  # TODO add in comment filters
+  "org/gnome/meld/wrap-mode": "'none'"

--- a/defaults/main/dconf.yml
+++ b/defaults/main/dconf.yml
@@ -21,6 +21,17 @@ gnome_base_settings:
     "org/gnome/desktop/wm/preferences/button-layout": "'close,maximize,minimize:appmenu'"
     "org/gnome/software/download-updates": "false"
     "org/gnome/software/first-run": "false"
+    "org/gnome/shell/favorite-apps": "['org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'firefox.desktop']"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings": "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/nautilus/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/terminal/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/mission_center/']"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/nautilus/name": "'nautilus'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/nautilus/command": "'nautilus'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/nautilus/binding": "'<Super>e'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/terminal/name": "'terminal'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/terminal/command": "'terminal'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/terminal/binding": "'<Super>t'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/mission_center/name": "'mission_center'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/mission_center/command": "'flatpak run io.missioncenter.MissionCenter'"
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/mission_center/binding": "'<Primary><Shift>Escape'"
   "40":
     # Note obsolete if custom theme gets set
     # "/org/gnome/desktop/interface/gtk-theme": "'Adwaita-dark'"

--- a/defaults/main/extensions.yml
+++ b/defaults/main/extensions.yml
@@ -1,6 +1,7 @@
 ---
 
 extension_path_system: "/usr/share/gnome-shell/extensions"
+gnome_systemwide_extensions_default_dconf: "/etc/dconf/db/local.d/20-gnome-extensions"
 
 obsolete_gnome_extensions:
   - apps-menu@gnome-shell-extensions.gcampax.github.com
@@ -25,6 +26,18 @@ gnome_extensions:
       Debian:
         - zip
         - gettext
+    dconf_settings:
+      "org/gnome/shell/extensions/tiling-assistant/enable-tiling-popup": "false"
+      "org/gnome/shell/extensions/tiling-assistant/active-window-hint-color": "'rgb(123,136,255)'"
+      "org/gnome/shell/extensions/tiling-assistant/restore-window": "['<Super>Down']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-bottom-half": "['<Super>KP_2']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-top-half": "['<Super>KP_8']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-left-half": "['<Super>Left', '<Super>KP_4']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-right-half": "['<Super>Right', '<Super>KP_6']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-topleft-quarter": "['<Super>KP_7']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-topright-quarter": "['<Super>KP_9']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-bottomleft-quarter": "['<Super>KP_1']"
+      "org/gnome/shell/extensions/tiling-assistant/tile-bottomright-quarter": "['<Super>KP_3']"
   - name: "dash-to-panel"
     address: "dash-to-panel@jderose9.github.com"
     id: 1160
@@ -35,6 +48,41 @@ gnome_extensions:
       Debian:
         - make
         - gettext
+    dconf_settings:
+      "org/gnome/shell/extensions/dash-to-panel/animate-appicon-hover": "false"
+      "org/gnome/shell/extensions/dash-to-panel/animate-appicon-hover-animation-convexity": "{'RIPPLE': 2.0, 'PLANK': 1.0, 'SIMPLE': 0.0}"
+      "org/gnome/shell/extensions/dash-to-panel/animate-appicon-hover-animation-extent": "{'RIPPLE': 4, 'PLANK': 4, 'SIMPLE': 1}"
+      "org/gnome/shell/extensions/dash-to-panel/animate-appicon-hover-animation-type": "'SIMPLE'"
+      "org/gnome/shell/extensions/dash-to-panel/appicon-margin": "0"
+      "org/gnome/shell/extensions/dash-to-panel/appicon-padding": "6"
+      "org/gnome/shell/extensions/dash-to-panel/dot-position": "'BOTTOM'"
+      "org/gnome/shell/extensions/dash-to-panel/dot-style-focused": "'DOTS'"
+      "org/gnome/shell/extensions/dash-to-panel/dot-style-unfocused": "'DASHES'"
+      "org/gnome/shell/extensions/dash-to-panel/group-apps": "true"
+      "org/gnome/shell/extensions/dash-to-panel/hotkeys-overlay-combo": "'TEMPORARILY'"
+      "org/gnome/shell/extensions/dash-to-panel/intellihide": "false"
+      "org/gnome/shell/extensions/dash-to-panel/intellihide-hide-from-windows": "true"
+      "org/gnome/shell/extensions/dash-to-panel/leftbox-padding": "-1"
+      "org/gnome/shell/extensions/dash-to-panel/leftbox-size": "14"
+      "org/gnome/shell/extensions/dash-to-panel/panel-anchors": "{'0':'MIDDLE'}"
+      "org/gnome/shell/extensions/dash-to-panel/panel-lengths": "{'0':100}"
+      "org/gnome/shell/extensions/dash-to-panel/panel-positions": "{'0':'BOTTOM'}"
+      "org/gnome/shell/extensions/dash-to-panel/panel-sizes": "{'0':48}"
+      "org/gnome/shell/extensions/dash-to-panel/primary-monitor": "0"
+      "org/gnome/shell/extensions/dash-to-panel/show-apps-icon-file": "''"
+      "org/gnome/shell/extensions/dash-to-panel/status-icon-padding": "4"
+      "org/gnome/shell/extensions/dash-to-panel/trans-bg-color": "'#613583'"
+      "org/gnome/shell/extensions/dash-to-panel/trans-gradient-bottom-color": "'#613583'"
+      "org/gnome/shell/extensions/dash-to-panel/trans-gradient-top-color": "'#dc8add'"
+      "org/gnome/shell/extensions/dash-to-panel/trans-panel-opacity": "0.2"
+      "org/gnome/shell/extensions/dash-to-panel/trans-use-custom-bg": "true"
+      "org/gnome/shell/extensions/dash-to-panel/trans-use-custom-gradient": "true"
+      "org/gnome/shell/extensions/dash-to-panel/trans-use-custom-opacity": "true"
+      "org/gnome/shell/extensions/dash-to-panel/trans-use-dynamic-opacity": "true"
+      "org/gnome/shell/extensions/dash-to-panel/tray-padding": "6"
+      "org/gnome/shell/extensions/dash-to-panel/tray-size": "16"
+      "org/gnome/shell/extensions/dash-to-panel/window-preview-title-position": "'TOP'"
+      "org/gnome/shell/extensions/dash-to-panel/hide-overview-on-startup": "true"
   - name: "system-monitor"
     address: "system-monitor@paradoxxx.zero.gmail.com"
     id: 120
@@ -48,9 +96,28 @@ gnome_extensions:
         - gir1.2-nm-1.0
         - gir1.2-clutter-1.0
         - gnome-system-monitor
+    dconf_settings:
+      "org/gnome/shell/extensions/system-monitor/compact-display": "true"
+      "org/gnome/shell/extensions/system-monitor/cpu-graph-width": "50"
+      "org/gnome/shell/extensions/system-monitor/cpu-individual-cores": "false"
+      "org/gnome/shell/extensions/system-monitor/cpu-style": "'graph'"
+      "org/gnome/shell/extensions/system-monitor/disk-display": "false"
+      "org/gnome/shell/extensions/system-monitor/freq-display": "false"
+      "org/gnome/shell/extensions/system-monitor/gpu-display": "false"
+      "org/gnome/shell/extensions/system-monitor/memory-graph-width": "50"
+      "org/gnome/shell/extensions/system-monitor/memory-style": "'graph'"
+      "org/gnome/shell/extensions/system-monitor/move-clock": "true"
+      "org/gnome/shell/extensions/system-monitor/net-graph-width": "50"
+      "org/gnome/shell/extensions/system-monitor/thermal-display": "false"
+      "org/gnome/shell/extensions/system-monitor/thermal-style": "'graph'"
   - name: "clipboard-indicator"
     address: "clipboard-indicator@tudmotu.com"
     id: 779
+    dconf_settings:
+      "org/gnome/shell/extensions/clipboard-indicator/move-item-first": "true"
+      "org/gnome/shell/extensions/clipboard-indicator/notify-on-copy": "true"
+      "org/gnome/shell/extensions/clipboard-indicator/toggle-menu": "['<Super>v']"
+      "org/gnome/shell/keybindings/toggle-message-tray": "@as []"
   - name: "sound-output-device-chooser"
     address: sound-output-device-chooser@kgshank.net
     id: 906

--- a/defaults/main/themes.yml
+++ b/defaults/main/themes.yml
@@ -8,12 +8,14 @@ gnome_wallpaper_src: "https://github.com/philnewm/gnome-dynamic-wallpapers/archi
 themes_path: "/usr/share/themes"
 icons_path: "/usr/share/icons"
 wallpapers_path: "/usr/share/backgrounds"
+gnome_systemwide_default_themes: "/etc/dconf/db/local.d/30-gnome-themes"
 
 theme_paths:
   - "{{ themes_path }}"
   - "{{ icons_path }}"
   - "{{ wallpapers_path }}"
 
+# Note "name" value needs to be equal to directory name
 gnome_themes:
   - name: "Lavanda-Dark"
     dependencies:
@@ -28,23 +30,34 @@ gnome_themes:
     install_cmd: "./install.sh --dest {{ themes_path }} --color dark --icon {{ ansible_facts.distribution | lower }} --libadwaita"
     download_dir: "Lavanda-gtk-theme/"
     install_dir: "Lavanda-gtk-theme-2024-04-28/"
+    dconf_settings:
+      "org/gnome/desktop/interface/gtk-theme": "'Lavanda-Dark'"
+      "org/gnome/shell/extensions/user-theme/name": "'Lavanda-Dark'"
   - name: "Tela-circle-purple-dark"
     repo_url: "{{ gnome_icon_theme_src }}"
     installer: "install.sh"
     install_cmd: "./install.sh -d {{ icons_path }} -c purple"
     download_dir: "Tela-circle-icon-theme/"
     install_dir: "Tela-circle-icon-theme-2025-02-10/"
+    dconf_settings:
+      "org/gnome/desktop/interface/icon-theme": "'Tela-circle-purple-dark'"
   - name: "Qogir-cursors"
     repo_url: "{{ gnome_cursor_theme_src }}"
     installer: "install.sh"
     install_cmd: "./install.sh"
     download_dir: "Qogir-icon-theme-2025-02-15/"
     install_dir: "Qogir-icon-theme-2025-02-15/src/cursors/"
+    dconf_settings:
+      "org/gnome/desktop/interface/cursor-theme": "'Qogir-cursors'"
   - name: "dynamic_wallpapers"
     repo_url: "{{ gnome_wallpaper_src }}"
     installer: "install.sh"
     install_cmd: "./install.sh"
     download_dir: "gnome-dynamic-wallpapers/"
     install_dir: "gnome-dynamic-wallpapers-main/"
+    dconf_settings:
+      "org/gnome/desktop/background/picture-options": "'zoom'"
+      "org/gnome/desktop/background/picture-uri": "'file:///usr/share/backgrounds/dynamic_wallpapers/BigSur.xml'"
+      "org/gnome/desktop/background/picture-uri-dark": "'file:///usr/share/backgrounds/dynamic_wallpapers/BigSur.xml'"
 
 ...

--- a/files/lavanda.xml
+++ b/files/lavanda.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<style-scheme id="lavanda" name="Lavanda" version="1.0">
+	<author/>
+	<_description>A lavanda theme based on womvamp</_description>
+	<style background="#2d2d2d" name="current-line"/>
+	<style background="#857b6f" bold="true" foreground="#f6f3e8" name="bracket-match"/>
+	<style background="#656565" name="cursor"/>
+	<style background="#1E1E1E" foreground="#f6f3e8" name="text"/>
+	<style background="#222222" foreground="#c161cc" name="line-numbers"/>
+	<style foreground="#99968b" italic="true" name="def:comment"/>
+	<style foreground="#e5786d" name="def:constant"/>
+	<style foreground="#95e454" italic="true" name="def:string"/>
+	<style foreground="#cae682" name="def:identifier"/>
+	<style foreground="#cae682" name="def:function"/>
+	<style foreground="#cae682" name="def:type"/>
+	<style foreground="#8ac6f2" name="def:statement"/>
+	<style foreground="#8ac6f2" name="def:keyword"/>
+	<style foreground="#e5786d" name="def:preprocessor"/>
+	<style foreground="#e5786d" name="def:number"/>
+	<style foreground="#e7f6da" name="def:specials"/>
+	<style foreground="#4A90E2" background="#2A2A2A" name="selection"/>
+</style-scheme>

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Update dconf
+  become: true
+  ansible.builtin.command:
+    cmd: "dconf update"
+  register: dconf_update_result
+  changed_when: dconf_update_result.rc == 0
+
 - name: Reboot Host
   become: true
   when:

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -1,42 +1,48 @@
 ---
 
-# - name: Get installed GNOME themes
-#   ansible.builtin.find:
-#     paths: "{{ theme_paths }}"
-#     file_type: "any"
-#     depth: 1
-#   register: theme_dirs
+- name: Get installed GNOME themes
+  ansible.builtin.find:
+    paths: "{{ theme_paths }}"
+    file_type: "any"
+    depth: 1
+  register: theme_dirs
 
-# - name: Set themes list (excluding 'hicolor')
-#   ansible.builtin.set_fact:
-#     themes: >-
-#       {{ theme_dirs.files
-#         | map(attribute='path')
-#         | map('basename')
-#         | reject('equalto', 'hicolor')
-#         | list }}
+- name: Set themes list (excluding 'hicolor')
+  ansible.builtin.set_fact:
+    themes: >-
+      {{ theme_dirs.files
+        | map(attribute='path')
+        | map('basename')
+        | reject('equalto', 'hicolor')
+        | list }}
 
-# - name: Remove themes
-#   become: true
-#   loop: "{{ themes }}"
-#   when: "'hicolor' not in item"
-#   ansible.builtin.file:
-#     path: "{{ item }}"
-#     state: absent
+- name: Remove themes
+  become: true
+  loop: "{{ themes }}"
+  when: "'hicolor' not in item"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
 
-# - name: Remove manual installed extensions
-#   become: true
-#   ansible.builtin.file:
-#     path: "{{ extension_path_system }}"
-#     state: absent
+- name: Remove manual installed extensions
+  become: true
+  ansible.builtin.file:
+    path: "{{ extension_path_system }}"
+    state: absent
 
-# - name: Set default target to multi-user
-#   become: true
-#   ansible.builtin.file:
-#     src: /usr/lib/systemd/system/multi-user.target
-#     dest: /etc/systemd/system/default.target
-#     state: link
-#   notify: Reboot Host
+- name: Remove system-wide default settings
+  become: true
+  ansible.builtin.file:
+    path: "/etc/dconf/db/local.d/"
+    state: absent
+
+- name: Set default target to multi-user
+  become: true
+  ansible.builtin.file:
+    src: /usr/lib/systemd/system/multi-user.target
+    dest: /etc/systemd/system/default.target
+    state: link
+  notify: Reboot Host
 
 - name: Remove Gnome packages dnf5
   become: true

--- a/tasks/gnome_extensions.yml
+++ b/tasks/gnome_extensions.yml
@@ -9,7 +9,7 @@
     group: root
     mode: "0755"
 
-- name: Get installed GNOME extensions
+- name: Get installed gnome extensions
   ansible.builtin.command:
     cmd: "ls {{ extension_path_system }}"
   register: extensions_list_result
@@ -57,7 +57,7 @@
   ansible.builtin.include_tasks:
     file: install_extensions.yml
 
-- name: Get installed GNOME extensions
+- name: Get installed gnome extensions
   ansible.builtin.command:
     cmd: "ls {{ extension_path_system }}"
   register: extensions_list_result
@@ -83,13 +83,40 @@
     group: root
     mode: "0755"
 
-- name: Configure GNOME Shell extensions system-wide
+- name: Enable gnome shell extensions by default system-wide
   become: true
   community.general.ini_file:
-    path: /etc/dconf/db/local.d/00-gnome-shell
+    path: "{{ gnome_systemwide_default_base }}"
     section: org/gnome/shell
     option: enabled-extensions
     value: "{{ extensions | to_json }}"
     mode: "0644"
+
+- name: Combine gnome extension dconf settings
+  ansible.builtin.set_fact:
+    gnome_extension_dconf_settings: >-
+      {{
+        gnome_extensions
+        | selectattr('dconf_settings', 'defined')
+        | map(attribute='dconf_settings')
+        | list
+        | ansible.builtin.combine
+      }}
+
+- name: Configure system-wide theme defaults
+  become: true
+  loop: "{{ gnome_extension_dconf_settings | dict2items }}"
+  loop_control:
+    label: "{{ dconf_pair.key }}"
+    loop_var: dconf_pair
+  community.general.ini_file:
+    path: "{{ gnome_systemwide_extensions_default_dconf }}"
+    section: "{{ dconf_pair.key | dirname }}"
+    option: "{{ dconf_pair.key | basename }}"
+    value: "{{ dconf_pair.value | string }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Update dconf
 
 ...

--- a/tasks/gnome_setup.yml
+++ b/tasks/gnome_setup.yml
@@ -7,6 +7,10 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
+  register: package_install_result
+  retries: 3
+  delay: 2
+  until: package_install_result is succeeded
 
 - name: Install system-wide flatpaks
   become: true
@@ -14,6 +18,10 @@
   community.general.flatpak:
     name: "{{ item }}"
     state: present
+  register: flatpak_install_result
+  retries: 3
+  delay: 2
+  until: flatpak_install_result is succeeded
 
 # TODO install fitting nvidia flatpack package `flatpak install org.freedesktop.Platform.GL.nvidia-<version>`
 
@@ -23,6 +31,148 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: absent
+
+- name: Gather package facts
+  ansible.builtin.package_facts:
+
+- name: Get Gnome version
+  become: true
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      gnome-shell --version | awk '{print $3}' | cut -d'.' -f1
+  args:
+    executable: /bin/bash
+  register: gnome_major_version_result
+  changed_when: false
+
+- name: Set gnome major version
+  become: true
+  ansible.builtin.set_fact:
+    gnome_major_version: "{{ gnome_major_version_result.stdout }}"
+
+- name: Configure system-wide gnome defaults
+  become: true
+  loop: "{{ gnome_base_settings.get(gnome_major_version, gnome_base_settings[gnome_settings_fallback]) | dict2items }}"
+  loop_control:
+    label: "{{ dconf_pair.key }}"
+    loop_var: dconf_pair
+  community.general.ini_file:
+    path: "{{ gnome_systemwide_default_base }}"
+    section: "{{ dconf_pair.key | dirname }}"
+    option: "{{ dconf_pair.key | basename }}"
+    value: "{{ dconf_pair.value | string }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Update dconf
+
+- name: Configure system-wide nautilus defaults
+  become: true
+  loop: "{{ gnome_nautilus_settings.get(gnome_major_version, gnome_nautilus_settings[gnome_settings_fallback]) | dict2items }}"
+  loop_control:
+    label: "{{ dconf_pair.key }}"
+    loop_var: dconf_pair
+  when: "'nautilus' in ansible_facts.packages"
+  community.general.ini_file:
+    path: "{{ gnome_systemwide_default_nautilus }}"
+    section: "{{ dconf_pair.key | dirname }}"
+    option: "{{ dconf_pair.key | basename }}"
+    value: "{{ dconf_pair.value | string }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Update dconf
+
+- name: Configure gnome-terminal defaults
+  when: "'gnome-terminal' in ansible_facts.packages"
+  block:
+    - name: Configure system-wide terminal defaults
+      become: true
+      loop: "{{ gnome_terminal_settings | dict2items }}"
+      loop_control:
+        label: "{{ dconf_pair.key }}"
+        loop_var: dconf_pair
+      community.general.ini_file:
+        path: "{{ gnome_systemwide_default_terminal }}"
+        section: "{{ dconf_pair.key | dirname }}"
+        option: "{{ dconf_pair.key | basename }}"
+        value: "{{ dconf_pair.value | string }}"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Update dconf
+
+    - name: Configure system-wide terminal default profile
+      become: true
+      loop: "{{ gnome_terminal_profile_settings | dict2items }}"
+      loop_control:
+        label: "{{ dconf_pair.key }}"
+        loop_var: dconf_pair
+      when: "'gnome-terminal' in ansible_facts.packages"
+      community.general.ini_file:
+        path: "{{ gnome_systemwide_default_terminal }}"
+        section: "{{ gnome_terminal_profile_path }}"
+        option: "{{ dconf_pair.key | basename }}"
+        value: "{{ dconf_pair.value | string }}"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Update dconf
+
+- name: Configure gedit defaults
+  when: "'gedit' in ansible_facts.packages"
+  block:
+    - name: Create gedit user theme directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ gedit_system_theme_path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Copy gedit theme
+      become: true
+      ansible.builtin.copy:
+        src: "lavanda.xml"
+        dest: "{{ gedit_system_theme_path }}/lavanda.xml"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Configure system-wide gedit defaults
+      become: true
+      loop: "{{ gnome_gedit_settings | dict2items }}"
+      loop_control:
+        label: "{{ dconf_pair.key }}"
+        loop_var: dconf_pair
+      community.general.ini_file:
+        path: "{{ gnome_systemwide_default_gedit }}"
+        section: "{{ dconf_pair.key | dirname }}"
+        option: "{{ dconf_pair.key | basename }}"
+        value: "{{ dconf_pair.value | string }}"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Update dconf
+
+- name: Configure system-wide meld defaults
+  become: true
+  loop: "{{ gnome_meld_settings | dict2items }}"
+  loop_control:
+    label: "{{ dconf_pair.key }}"
+    loop_var: dconf_pair
+  when: "'meld' in ansible_facts.packages"
+  community.general.ini_file:
+    path: "{{ gnome_systemwide_default_meld }}"
+    section: "{{ dconf_pair.key | dirname }}"
+    option: "{{ dconf_pair.key | basename }}"
+    value: "{{ dconf_pair.value | string }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Update dconf
 
 - name: Adjust almalinux home mapper for disk analyzer usage
   when: ansible_facts.distribution | lower == "almalinux"

--- a/tasks/gnome_setup.yml
+++ b/tasks/gnome_setup.yml
@@ -31,8 +31,10 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: absent
+  register: package_uninstall_result
 
 - name: Gather package facts
+  when: package_install_result.changed or package_uninstall_result.changed
   ansible.builtin.package_facts:
 
 - name: Get Gnome version

--- a/tasks/gnome_themes.yml
+++ b/tasks/gnome_themes.yml
@@ -20,4 +20,31 @@
   ansible.builtin.include_tasks:
     file: install_themes.yml
 
+- name: Combine gnome theme dconf settings
+  ansible.builtin.set_fact:
+    gnome_theme_dconf_settings: >-
+      {{
+        gnome_extensions
+        | selectattr('dconf_settings', 'defined')
+        | map(attribute='dconf_settings')
+        | list
+        | ansible.builtin.combine
+      }}
+
+- name: Configure system-wide theme defaults
+  become: true
+  loop: "{{ gnome_theme_dconf_settings | dict2items }}"
+  loop_control:
+    label: "{{ dconf_pair.key }}"
+    loop_var: dconf_pair
+  community.general.ini_file:
+    path: "{{ gnome_systemwide_default_themes }}"
+    section: "{{ dconf_pair.key | dirname }}"
+    option: "{{ dconf_pair.key | basename }}"
+    value: "{{ dconf_pair.value | string }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Update dconf
+
 ...

--- a/tasks/install_extensions.yml
+++ b/tasks/install_extensions.yml
@@ -4,8 +4,11 @@
   become: true
   ansible.builtin.command:
     cmd: "gnome-shell-extension-installer {{ extension.id }} --yes"
-  register: result
-  changed_when: result.rc == 0
+  register: extension_install_result
+  changed_when: extension_install_result.rc == 0
+  retries: 3
+  delay: 2
+  until: extension_install_result is succeeded
 
 - name: Install extension dependencies
   become: true
@@ -14,5 +17,9 @@
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
+  register: extension_dependency_install_result
+  retries: 3
+  delay: 2
+  until: extension_dependency_install_result is succeeded
 
 ...

--- a/tasks/install_themes.yml
+++ b/tasks/install_themes.yml
@@ -16,14 +16,16 @@
     dest: "{{ install_dir }}/"
     remote_src: true
   register: download_result
+  retries: 3
+  delay: 2
   until: download_result is succeeded
-  retries: 5
-  delay: 10
 
 - name: Update installer permissions
   become: true
   ansible.builtin.file:
     path: "{{ (install_dir, theme.install_dir, theme.installer) | ansible.builtin.path_join }}"
+    owner: root
+    group: root
     mode: "0755"
 
 - name: Install theme dependencies


### PR DESCRIPTION
Write system-wide `dconf` defaults.

This includes extensions and themes as well as cleanup logic